### PR TITLE
fix: Ensure the automatically added Diligence license displays correctly

### DIFF
--- a/Sources/Diligence/Model/License.swift
+++ b/Sources/Diligence/Model/License.swift
@@ -20,13 +20,17 @@
 
 import Foundation
 
-public struct License: Identifiable {
+public struct License: Identifiable, Hashable {
 
     public var id = UUID()
 
     public let name: String
     public let author: String
     public let text: String
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
 
     public init(name: String, author: String, text: String) {
         self.name = name
@@ -48,5 +52,14 @@ public struct License: Identifiable {
         self.init(name: name, author: author, filename: filename, bundle: bundle)
     }
 
+
+}
+
+extension Array where Element == License {
+
+    /// Return an array ensuing the built-in Diligence license exists, and exists only once in the array.
+    func includingDiligenceLicense() -> Array<License> {
+        return Array(Set(self + [Legal.license]))
+    }
 
 }

--- a/Sources/Diligence/Scenes/MacLicenseWindowGroup.swift
+++ b/Sources/Diligence/Scenes/MacLicenseWindowGroup.swift
@@ -31,7 +31,7 @@ struct MacLicenseWindowGroup: Scene {
 
     var body: some Scene {
         WindowGroup(id: Self.windowID, for: License.ID.self) { $licenseId in
-            if let license = licenses.first(where: { $0.id == licenseId }) {
+            if let license = licenses.includingDiligenceLicense().first(where: { $0.id == licenseId }) {
                 MacLicenseView(license: license)
             }
         }

--- a/Sources/Diligence/Views/MacAboutView.swift
+++ b/Sources/Diligence/Views/MacAboutView.swift
@@ -68,7 +68,7 @@ public struct MacAboutView: View {
         self.copyright = copyright
         self.actions = actions
         self.acknowledgements = acknowledgements
-        self.licenses = (licenses + [Legal.license]).sorted {
+        self.licenses = licenses.includingDiligenceLicense().sorted {
             $0.name.localizedCompare($1.name) == .orderedAscending
         }
         self.usesAppKit = usesAppKit


### PR DESCRIPTION
While we were automatically adding the Diligence license to the array of licenses used in the `MacAboutView`, it was not being added to the array of licenses used to service the license windows, meaning that creating a new license by ID would fail to look up the built-in license.