### PR TITLE
feat: Support multiple license groups

### DIFF
--- a/Sources/Diligence/Builders/LicenseGroupsBuilder.swift
+++ b/Sources/Diligence/Builders/LicenseGroupsBuilder.swift
@@ -1,0 +1,50 @@
+// Copyright (c) 2018-2023 InSeven Limited
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+public protocol LicenseGroupsConvertible {
+    func asLicenseGroups() -> [LicenseGroup]
+}
+
+@resultBuilder public struct LicenseGroupsBuilder {
+
+    public static func buildBlock() -> [LicenseGroup] {
+        return []
+    }
+
+    public static func buildBlock(_ licenseGroup: LicenseGroup...) -> [LicenseGroup] {
+        return licenseGroup
+    }
+
+    public static func buildBlock(_ values: LicenseGroupsConvertible...) -> [LicenseGroup] {
+        return values
+            .flatMap { $0.asLicenseGroups() }
+    }
+
+}
+
+extension Array: LicenseGroupsConvertible where Element == LicenseGroup {
+
+    public func asLicenseGroups() -> [LicenseGroup] {
+        return self
+    }
+
+}

--- a/Sources/Diligence/Model/Contents.swift
+++ b/Sources/Diligence/Model/Contents.swift
@@ -26,20 +26,30 @@ public struct Contents {
     let copyright: String?
     let actions: [Action]
     let acknowledgements: [Acknowledgements]
-    let licenses: [License]
+    let licenseGroups: [LicenseGroup]
+
+    public init(repository: String? = nil,
+                copyright: String? = nil,
+                @ActionsBuilder actions: () -> [Action],
+                @AcknowledgementsBuilder acknowledgements: () -> [Acknowledgements] = { [] },
+                @LicenseGroupsBuilder licenses: () -> [LicenseGroup] = { [] }) {
+        self.repository = repository
+        self.copyright = copyright
+        self.actions = actions()
+        self.acknowledgements = acknowledgements()
+        self.licenseGroups = licenses()
+    }
 
     public init(repository: String? = nil,
                 copyright: String? = nil,
                 @ActionsBuilder actions: () -> [Action],
                 @AcknowledgementsBuilder acknowledgements: () -> [Acknowledgements] = { [] },
                 @LicensesBuilder licenses: () -> [License] = { [] }) {
-        self.repository = repository
-        self.copyright = copyright
-        self.actions = actions()
-        self.acknowledgements = acknowledgements()
-        self.licenses = (licenses() + [Legal.license]).sorted {
-            $0.name.localizedCompare($1.name) == .orderedAscending
-        }
+        self.init(repository: repository,
+                  copyright: copyright,
+                  actions: actions,
+                  acknowledgements: acknowledgements,
+                  licenses: { LicenseGroup("Licenses", includeDiligenceLicense: true, licenses: licenses()) })
     }
 
 }

--- a/Sources/Diligence/Model/License.swift
+++ b/Sources/Diligence/Model/License.swift
@@ -64,7 +64,7 @@ extension Array where Element == License {
 
     /// Return an array ensuing the built-in Diligence license exists, and exists only once in the array.
     func includingDiligenceLicense() -> [License] {
-        return Array(Set(self + [Legal.license]))
+        return self + [Legal.license]
     }
 
     /// Sort licenses alphabetically by name.

--- a/Sources/Diligence/Model/License.swift
+++ b/Sources/Diligence/Model/License.swift
@@ -63,8 +63,15 @@ public struct License: Identifiable, Hashable {
 extension Array where Element == License {
 
     /// Return an array ensuing the built-in Diligence license exists, and exists only once in the array.
-    func includingDiligenceLicense() -> Array<License> {
+    func includingDiligenceLicense() -> [License] {
         return Array(Set(self + [Legal.license]))
+    }
+
+    /// Sort licenses alphabetically by name.
+    func sorted() -> [License] {
+        return sorted {
+            $0.name.localizedCompare($1.name) == .orderedAscending
+        }
     }
 
 }

--- a/Sources/Diligence/Model/LicenseGroup.swift
+++ b/Sources/Diligence/Model/LicenseGroup.swift
@@ -1,0 +1,43 @@
+// Copyright (c) 2018-2023 InSeven Limited
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import SwiftUI
+
+public struct LicenseGroup: Identifiable {
+
+    public let id = UUID()
+
+    let title: String
+    let licenses: [License]
+
+    public init(_ title: String, includeDiligenceLicense: Bool = false, licenses: [License]) {
+        self.title = title
+        if includeDiligenceLicense {
+            self.licenses = licenses.includingDiligenceLicense()
+        } else {
+            self.licenses = licenses
+        }
+    }
+
+    public init(_ title: String, includeDiligenceLicense: Bool = false, @LicensesBuilder licenses: () -> [License]) {
+        self.init(title, includeDiligenceLicense: includeDiligenceLicense, licenses: licenses())
+    }
+
+}

--- a/Sources/Diligence/Model/LicenseGroup.swift
+++ b/Sources/Diligence/Model/LicenseGroup.swift
@@ -20,7 +20,7 @@
 
 import SwiftUI
 
-public struct LicenseGroup: Identifiable {
+public struct LicenseGroup: Identifiable, Equatable {
 
     public let id = UUID()
 

--- a/Sources/Diligence/Scenes/AboutWindowGroup.swift
+++ b/Sources/Diligence/Scenes/AboutWindowGroup.swift
@@ -43,7 +43,7 @@ public struct AboutWindowGroup: Scene {
         self.copyright = copyright
         self.actions = actions()
         self.acknowledgements = acknowledgements()
-        self.licenseGroups = licenseGroups
+        self.licenseGroups = licenses()
     }
 
     public init(repository: String? = nil,
@@ -51,11 +51,6 @@ public struct AboutWindowGroup: Scene {
                 @ActionsBuilder actions: () -> [Action],
                 @AcknowledgementsBuilder acknowledgements: () -> [Acknowledgements] = { [] },
                 @LicensesBuilder licenses: () -> [License] = { [] }) {
-        self.repository = repository
-        self.copyright = copyright
-        self.actions = actions()
-        self.acknowledgements = acknowledgements()
-        self.licenses = licenses()
         self.init(repository: repository,
                   copyright: copyright,
                   actions: actions,

--- a/Sources/Diligence/Scenes/AboutWindowGroup.swift
+++ b/Sources/Diligence/Scenes/AboutWindowGroup.swift
@@ -32,7 +32,19 @@ public struct AboutWindowGroup: Scene {
     private let copyright: String?
     private let actions: [Action]
     private let acknowledgements: [Acknowledgements]
-    private let licenses: [License]
+    private let licenseGroups: [LicenseGroup]
+
+    public init(repository: String? = nil,
+                copyright: String? = nil,
+                @ActionsBuilder actions: () -> [Action],
+                @AcknowledgementsBuilder acknowledgements: () -> [Acknowledgements] = { [] },
+                @LicenseGroupsBuilder licenses: () -> [LicenseGroup] = { [] }) {
+        self.repository = repository
+        self.copyright = copyright
+        self.actions = actions()
+        self.acknowledgements = acknowledgements()
+        self.licenseGroups = licenseGroups
+    }
 
     public init(repository: String? = nil,
                 copyright: String? = nil,
@@ -44,6 +56,11 @@ public struct AboutWindowGroup: Scene {
         self.actions = actions()
         self.acknowledgements = acknowledgements()
         self.licenses = licenses()
+        self.init(repository: repository,
+                  copyright: copyright,
+                  actions: actions,
+                  acknowledgements: acknowledgements,
+                  licenses: { LicenseGroup("Licenses", includeDiligenceLicense: true, licenses: licenses()) })
     }
 
     public init(_ contents: Contents) {
@@ -51,7 +68,7 @@ public struct AboutWindowGroup: Scene {
         self.copyright = contents.copyright
         self.actions = contents.actions
         self.acknowledgements = contents.acknowledgements
-        self.licenses = contents.licenses
+        self.licenseGroups = contents.licenseGroups
     }
 
     public var body: some Scene {
@@ -59,11 +76,11 @@ public struct AboutWindowGroup: Scene {
                        copyright: copyright,
                        actions: actions,
                        acknowledgements: acknowledgements,
-                       licenses: licenses)
+                       licenseGroups: licenseGroups)
         .commands {
             AboutCommands()
         }
-        MacLicenseWindowGroup(licenses: licenses)
+        MacLicenseWindowGroup(licenses: licenseGroups.flatMap { $0.licenses })
     }
 
 }

--- a/Sources/Diligence/Scenes/MacAboutWindow.swift
+++ b/Sources/Diligence/Scenes/MacAboutWindow.swift
@@ -31,18 +31,18 @@ struct MacAboutWindow: Scene {
     private let copyright: String?
     private let actions: [Action]
     private let acknowledgements: [Acknowledgements]
-    private let licenses: [License]
+    private let licenseGroups: [LicenseGroup]
 
     init(repository: String? = nil,
          copyright: String? = nil,
          actions: [Action],
          acknowledgements: [Acknowledgements],
-         licenses: [License]) {
+         licenseGroups: [LicenseGroup]) {
         self.repository = repository
         self.copyright = copyright
         self.actions = actions
         self.acknowledgements = acknowledgements
-        self.licenses = licenses
+        self.licenseGroups = licenseGroups
     }
 
     var body: some Scene {
@@ -51,7 +51,7 @@ struct MacAboutWindow: Scene {
                          copyright: copyright,
                          actions: actions,
                          acknowledgements: acknowledgements,
-                         licenses: licenses)
+                         licenseGroups: licenseGroups)
             .navigationTitle(Bundle.main.aboutWindowTitle)
         }
         .windowResizability(.contentSize)

--- a/Sources/Diligence/Views/LicenseSection.swift
+++ b/Sources/Diligence/Views/LicenseSection.swift
@@ -27,12 +27,11 @@ public struct LicenseSection: View {
 
     public init(_ title: String? = nil, _ licenses: [License]) {
         self.title = title
-        self.licenses = licenses
+        self.licenses = licenses.sorted()
     }
 
     public init(_ title: String? = nil, @LicensesBuilder licenses: () -> [License]) {
-        self.title = title
-        self.licenses = licenses()
+        self.init(title, licenses())
     }
 
     public var body: some View {

--- a/Sources/Diligence/Views/MacAboutView.swift
+++ b/Sources/Diligence/Views/MacAboutView.swift
@@ -94,9 +94,9 @@ public struct MacAboutView: View {
                 usesAppKit: Bool = false) {
         self.init(repository: repository,
                   copyright: copyright,
-                  actions: actions(),
-                  acknowledgements: acknowledgements(),
-                  licenses: licenses(),
+                  actions: actions,
+                  acknowledgements: acknowledgements,
+                  licenses: { LicenseGroup("Licenses", includeDiligenceLicense: true, licenses: licenses()) },
                   usesAppKit: usesAppKit)
     }
 

--- a/Sources/Diligence/Views/MacAboutView.swift
+++ b/Sources/Diligence/Views/MacAboutView.swift
@@ -76,14 +76,14 @@ public struct MacAboutView: View {
          copyright: String? = nil,
          actions: [Action],
          acknowledgements: [Acknowledgements],
-         licenses: [License],
+         licenseGroups: [LicenseGroup],
          usesAppKit: Bool = false) {
-        self.init(repository: repository,
-                  copyright: copyright,
-                  actions: actions,
-                  acknowledgements: acknowledgements,
-                  licenses: { LicenseGroup("Licenses", includeDiligenceLicense: true, licenses: licenses()) },
-                  usesAppKit: usesAppKit)
+        self.repository = repository
+        self.copyright = copyright
+        self.actions = actions
+        self.acknowledgements = acknowledgements
+        self.licenseGroups = licenseGroups
+        self.usesAppKit = usesAppKit
     }
 
     public init(repository: String? = nil,

--- a/Sources/Diligence/Views/PhoneAboutView.swift
+++ b/Sources/Diligence/Views/PhoneAboutView.swift
@@ -71,7 +71,7 @@ public struct PhoneAboutView: View {
         self.copyright = contents.copyright
         self.actions = contents.actions
         self.acknowledgements = contents.acknowledgements
-        self.licenseGroups = [LicenseGroup("Licenses", licenses: contents.licenses)]
+        self.licenseGroups = contents.licenseGroups
     }
 
     public var body: some View {

--- a/Sources/Diligence/Views/PhoneAboutView.swift
+++ b/Sources/Diligence/Views/PhoneAboutView.swift
@@ -35,7 +35,7 @@ public struct PhoneAboutView: View {
     private let copyright: String?
     private let actions: [Action]
     private let acknowledgements: [Acknowledgements]
-    private let licenses: [License]
+    private let licenseGroups: [LicenseGroup]
 
     @State var isHeaderVisible: Bool = true
 
@@ -43,15 +43,28 @@ public struct PhoneAboutView: View {
                 copyright: String? = nil,
                 @ActionsBuilder actions: () -> [Action] = { [] },
                 @AcknowledgementsBuilder acknowledgements: () -> [Acknowledgements] = { [] },
-                @LicensesBuilder licenses: () -> [License] = { [] },
+                @LicenseGroupsBuilder licenses: () -> [LicenseGroup] = { [ ] },
                 usesAppKit: Bool = false) {
         self.repository = repository
         self.copyright = copyright
         self.actions = actions()
         self.acknowledgements = acknowledgements()
-        self.licenses = (licenses() + [Legal.license]).sorted {
-            $0.name.localizedCompare($1.name) == .orderedAscending
-        }
+        self.licenseGroups = licenses()
+    }
+
+    public init(repository: String? = nil,
+                copyright: String? = nil,
+                @ActionsBuilder actions: () -> [Action] = { [] },
+                @AcknowledgementsBuilder acknowledgements: () -> [Acknowledgements] = { [] },
+                @LicensesBuilder licenses: () -> [License] = { [] },
+                usesAppKit: Bool = false) {
+        self.init(repository: repository,
+                  copyright: copyright,
+                  actions: actions,
+                  acknowledgements: acknowledgements,
+                  licenses: {
+            LicenseGroup("Licenses", includeDiligenceLicense: true, licenses: licenses())
+        }, usesAppKit: usesAppKit)
     }
 
     public init(_ contents: Contents) {
@@ -59,7 +72,7 @@ public struct PhoneAboutView: View {
         self.copyright = contents.copyright
         self.actions = contents.actions
         self.acknowledgements = contents.acknowledgements
-        self.licenses = contents.licenses
+        self.licenseGroups = [LicenseGroup("Licenses", licenses: contents.licenses)]
     }
 
     public var body: some View {
@@ -86,7 +99,9 @@ public struct PhoneAboutView: View {
                 ForEach(acknowledgements.filter { !$0.credits.isEmpty }) { acknowledgement in
                     CreditSection(acknowledgement.title, acknowledgement.credits)
                 }
-                LicenseSection("Licenses", licenses)
+                ForEach(licenseGroups) { licenseGroup in
+                    LicenseSection(licenseGroup.title, licenseGroup.licenses)
+                }
             }
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/Sources/Diligence/Views/PhoneAboutView.swift
+++ b/Sources/Diligence/Views/PhoneAboutView.swift
@@ -62,9 +62,8 @@ public struct PhoneAboutView: View {
                   copyright: copyright,
                   actions: actions,
                   acknowledgements: acknowledgements,
-                  licenses: {
-            LicenseGroup("Licenses", includeDiligenceLicense: true, licenses: licenses())
-        }, usesAppKit: usesAppKit)
+                  licenses: { LicenseGroup("Licenses", includeDiligenceLicense: true, licenses: licenses()) },
+                  usesAppKit: usesAppKit)
     }
 
     public init(_ contents: Contents) {

--- a/Tests/DiligenceTests/DiligenceTests.swift
+++ b/Tests/DiligenceTests/DiligenceTests.swift
@@ -1,5 +1,87 @@
+// Copyright (c) 2018-2023 InSeven Limited
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 import XCTest
 @testable import Diligence
 
 final class DiligenceTests: XCTestCase {
+
+    func testEquivalence() {
+
+        XCTAssertNotEquivalent([License("Fromage", author: "Fromage", text: "skdjfh")],
+                               [License("Cheese", author: "Fromage", text: "skdjfh")])
+
+        XCTAssertNotEquivalent([License("Cheese", author: "Fromage", text: "skdjfh")],
+                               [License("Cheese", author: "Fromage", text: "skdjfkjshdfh")])
+
+        XCTAssertNotEquivalent([License("Cheese", author: "Fromage", text: "skdjfh")],
+                            [License("Cheese", author: "Random", text: "skdjfh")])
+
+        XCTAssertEquivalent([License("Cheese", author: "Fromage", text: "skdjfh")],
+                            [License("Cheese", author: "Fromage", text: "skdjfh")])
+    }
+
+    func testContents() {
+        let contents = Contents(repository: "foo/bar",
+                                copyright: "Copyright") {
+            Action("Website", url: URL(string: "https://example.com")!)
+        } acknowledgements: {
+            Acknowledgements("Thanks") {
+                Credit("The World")
+            }
+        } licenses: {
+            License("Name", author: "Author", text: "License")
+        }
+        XCTAssertEquivalent(contents.licenseGroups,
+                            [LicenseGroup("Licenses", licenses: [
+                                License("Name", author: "Author", text: "License"),
+                                Diligence.Legal.license,
+                            ])])
+    }
+
+    func testLicenseGroup() {
+
+        let licenseGroup = LicenseGroup("Fonts") {
+            License("One", author: "Two", text: "Three")
+            License("Four", author: "Five", text: "Six")
+        }
+        XCTAssertEqual(licenseGroup.title, "Fonts")
+        XCTAssertEquivalent(licenseGroup.licenses, [
+            License("One", author: "Two", text: "Three"),
+            License("Four", author: "Five", text: "Six")
+        ])
+
+    }
+
+    func testLicenseGroupIncludingDiligenceLicense() {
+
+        let licenseGroup = LicenseGroup("Fonts", includeDiligenceLicense: true) {
+            License("One", author: "Two", text: "Three")
+            License("Four", author: "Five", text: "Six")
+        }
+        XCTAssertEqual(licenseGroup.title, "Fonts")
+        XCTAssertEquivalent(licenseGroup.licenses, [
+            License("One", author: "Two", text: "Three"),
+            License("Four", author: "Five", text: "Six"),
+            Diligence.Legal.license
+        ])
+    }
+
 }

--- a/Tests/DiligenceTests/Equivalence.swift
+++ b/Tests/DiligenceTests/Equivalence.swift
@@ -1,0 +1,84 @@
+// Copyright (c) 2018-2023 InSeven Limited
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import XCTest
+
+@testable import Diligence
+
+protocol Equivalence {
+
+    func isEquivalent(_ other: Self) -> Bool
+
+}
+
+extension Array: Equivalence where Element: Equivalence {
+
+    func isEquivalent(_ other: Array<Element>) -> Bool {
+        return elementsEqual(other) { lhs, rhs in
+            return lhs.isEquivalent(rhs)
+        }
+    }
+
+}
+
+extension LicenseGroup: Equivalence {
+
+    func isEquivalent(_ other: LicenseGroup) -> Bool {
+        return (self.title == other.title &&
+                self.licenses.isEquivalent(other.licenses))
+    }
+
+}
+
+extension License: Equivalence {
+
+    func isEquivalent(_ other: License) -> Bool {
+        return (self.name == other.name &&
+                self.author == other.author &&
+                self.text == other.text)
+    }
+
+}
+
+func XCTAssertEquivalent<T>(_ expression1: @autoclosure () -> T,
+                            _ expression2: @autoclosure () -> T,
+                            _ message: @autoclosure () -> String = "",
+                            file: StaticString = #filePath,
+                            line: UInt = #line) where T : Equivalence {
+    let value1 = expression1()
+    let value2 = expression2()
+    if value1.isEquivalent(value2) {
+        return
+    }
+    XCTFail("\(value1) is not equivalent to \(value2)", file: file, line: line)
+}
+
+func XCTAssertNotEquivalent<T>(_ expression1: @autoclosure () -> T,
+                            _ expression2: @autoclosure () -> T,
+                            _ message: @autoclosure () -> String = "",
+                            file: StaticString = #filePath,
+                            line: UInt = #line) where T : Equivalence {
+    let value1 = expression1()
+    let value2 = expression2()
+    if !value1.isEquivalent(value2) {
+        return
+    }
+    XCTFail("\(value1) is equivalent to \(value2)", file: file, line: line)
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -10,5 +10,11 @@ ROOT_DIRECTORY="${SCRIPT_DIRECTORY}/.."
 cd "$ROOT_DIRECTORY"
 
 xcodebuild -scheme Diligence -showdestinations
+
+# Build.
 xcodebuild -scheme Diligence -destination "platform=macOS" clean build
 xcodebuild -scheme Diligence -destination "platform=iOS Simulator,name=iPhone 14 Pro" clean build
+
+# Test.
+xcodebuild -scheme Diligence -destination "platform=macOS" test
+xcodebuild -scheme Diligence -destination "platform=iOS Simulator,name=iPhone 14 Pro" test


### PR DESCRIPTION
This change adds support for grouping licenses into multiple sections. For example, it might be necessary to separate font licenses from source licenses (lookin' at you StatusPanel).