### PR TITLE
fix: Guard macOS specific code when building for iOS

### DIFF
--- a/Sources/Diligence/Views/AboutLink.swift
+++ b/Sources/Diligence/Views/AboutLink.swift
@@ -20,6 +20,8 @@
 
 import SwiftUI
 
+#if compiler(>=5.7) && os(macOS)
+
 @available(macOS 13.0, *)
 @available(iOS, unavailable)
 @available(tvOS, unavailable)
@@ -48,3 +50,5 @@ public struct AboutLink<Label>: View where Label: View {
     }
 
 }
+
+#endif


### PR DESCRIPTION
This fixes a regression which leaked some macOS specific code into iOS builds causing them to break.