### PR TITLE
feat: Support `Licensable` protocol

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/inseven/licensable",
         "state": {
           "branch": null,
-          "revision": "192b84b28cd7037b0beb8ed13d73c9d90ca0aefd",
-          "version": "0.0.8"
+          "revision": "e70ba15aad836c880024ec6e9f6f09e472fac956",
+          "version": "0.0.9"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Licensable",
+        "repositoryURL": "https://github.com/inseven/licensable",
+        "state": {
+          "branch": null,
+          "revision": "192b84b28cd7037b0beb8ed13d73c9d90ca0aefd",
+          "version": "0.0.8"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
             targets: ["Diligence"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/inseven/licensable", from: "0.0.8"),
+        .package(url: "https://github.com/inseven/licensable", from: "0.0.9"),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
             targets: ["Diligence"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/inseven/licensable", from: "0.0.3"),
+        .package(url: "https://github.com/inseven/licensable", from: "0.0.8"),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,4 @@
 // swift-tools-version:5.5
-// The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
@@ -10,7 +9,6 @@ let package = Package(
         .macOS(.v12)
     ],
     products: [
-        // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "Diligence",
             targets: ["Diligence"]),
@@ -19,8 +17,6 @@ let package = Package(
         .package(url: "https://github.com/inseven/licensable", from: "0.0.3"),
     ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "Diligence",
             dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -16,15 +16,16 @@ let package = Package(
             targets: ["Diligence"]),
     ],
     dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
+        .package(url: "https://github.com/inseven/licensable", from: "0.0.3"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "Diligence",
-            dependencies: [],
+            dependencies: [
+                .product(name: "Licensable", package: "licensable"),
+            ],
             resources: [.process("Resources")]),
         .testTarget(
             name: "DiligenceTests",

--- a/Sources/Diligence/Builders/LicensesBuilder.swift
+++ b/Sources/Diligence/Builders/LicensesBuilder.swift
@@ -20,38 +20,40 @@
 
 import Foundation
 
+import Licensable
+
 public protocol LicensesConvertible {
-    func asLicenses() -> [License]
+    func asLicenses() -> [Licensable]
 }
 
 @resultBuilder public struct LicensesBuilder {
 
-    public static func buildBlock() -> [License] {
+    public static func buildBlock() -> [Licensable] {
         return []
     }
 
-    public static func buildBlock(_ licenses: License...) -> [License] {
+    public static func buildBlock(_ licenses: Licensable...) -> [Licensable] {
         return licenses
     }
 
-    public static func buildBlock(_ values: LicensesConvertible...) -> [License] {
+    public static func buildBlock(_ values: LicensesConvertible...) -> [Licensable] {
         return values
             .flatMap { $0.asLicenses() }
     }
 
-    public static func buildExpression(_ expression: License) -> [License] {
+    public static func buildExpression(_ expression: Licensable) -> [Licensable] {
         return [expression]
     }
 
-    public static func buildArray(_ components: [[License]]) -> [License] {
+    public static func buildArray(_ components: [[Licensable]]) -> [Licensable] {
         return Array(components.joined())
     }
 
 }
 
-extension Array: LicensesConvertible where Element == License {
+extension Array: LicensesConvertible where Element == Licensable {
 
-    public func asLicenses() -> [License] {
+    public func asLicenses() -> [Licensable] {
         return self
     }
 

--- a/Sources/Diligence/Extensions/Array.swift
+++ b/Sources/Diligence/Extensions/Array.swift
@@ -20,9 +20,11 @@
 
 import Foundation
 
-extension Array where Element == License {
+import Licensable
 
-    func sortedByName() -> [License] {
+extension Array where Element == Licensable {
+
+    func sortedByName() -> [Licensable] {
         return sorted { lhs, rhs in
             return lhs.name.localizedStandardCompare(rhs.name) == .orderedAscending
         }

--- a/Sources/Diligence/Extensions/Array.swift
+++ b/Sources/Diligence/Extensions/Array.swift
@@ -24,6 +24,12 @@ import Licensable
 
 extension Array where Element == Licensable {
 
+    /// Return an array ensuing the built-in Diligence license exists, and exists only once in the array.
+    func includingDiligenceLicense() -> [Licensable] {
+        return self + [.diligence]
+    }
+
+    /// Sort licenses alphabetically by name.
     func sortedByName() -> [Licensable] {
         return sorted { lhs, rhs in
             return lhs.name.localizedStandardCompare(rhs.name) == .orderedAscending

--- a/Sources/Diligence/Extensions/Licensable.swift
+++ b/Sources/Diligence/Extensions/Licensable.swift
@@ -18,38 +18,18 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import SwiftUI
+import Foundation
 
 import Licensable
 
-struct LicenseView: View {
+extension Licensable where Self == License {
 
-    private var license: Licensable
-
-    init(_ license: Licensable) {
-        self.license = license
-    }
-
-    var body: some View {
-        List {
-            LabeledContent("Author", value: license.author)
-            ForEach(license.attributes) { attribute in
-                switch attribute.value {
-                case .text(let text):
-                    LabeledContent(attribute.name, value: text)
-                case .url(let url):
-                    Link(attribute.name, url: url)
-                }
-            }
-            .prefersTextualRepresentation()
-            Text(license.text)
-                .textSelection(.enabled)
-                .padding(.top, 8)
-        }
-        .listStyle(PlainListStyle())
-#if os(iOS)
-        .navigationBarTitle(license.name, displayMode: .inline)
-#endif
+    public static var diligence: License {
+        let licenseURL = Bundle.module.url(forResource: "LICENSE", withExtension: nil)!
+        return License(id: "https://github.com/inseven/diligence",
+                       name: "Diligence",
+                       author: "Jsaon Morley",
+                       text: try! String(contentsOf: licenseURL))
     }
 
 }

--- a/Sources/Diligence/Extensions/Licensable.swift
+++ b/Sources/Diligence/Extensions/Licensable.swift
@@ -28,7 +28,7 @@ extension Licensable where Self == License {
         let licenseURL = Bundle.module.url(forResource: "LICENSE", withExtension: nil)!
         return License(id: "https://github.com/inseven/diligence",
                        name: "Diligence",
-                       author: "Jsaon Morley",
+                       author: "Jason Morley",
                        text: try! String(contentsOf: licenseURL),
                        licenses: [
                            .licensable

--- a/Sources/Diligence/Extensions/Licensable.swift
+++ b/Sources/Diligence/Extensions/Licensable.swift
@@ -29,7 +29,10 @@ extension Licensable where Self == License {
         return License(id: "https://github.com/inseven/diligence",
                        name: "Diligence",
                        author: "Jsaon Morley",
-                       text: try! String(contentsOf: licenseURL))
+                       text: try! String(contentsOf: licenseURL),
+                       licenses: [
+                           .licensable
+                       ])
     }
 
 }

--- a/Sources/Diligence/Extensions/NSWindow.swift
+++ b/Sources/Diligence/Extensions/NSWindow.swift
@@ -23,6 +23,8 @@
 import AppKit
 import SwiftUI
 
+import Licensable
+
 extension NSWindow {
 
     @available(macOS 13, *)
@@ -30,7 +32,7 @@ extension NSWindow {
                             copyright: String? = nil,
                             @ActionsBuilder actions: () -> [Action],
                             @AcknowledgementsBuilder acknowledgements: () -> [Acknowledgements] = { [] },
-                            @LicensesBuilder licenses: () -> [License] = { [] }) {
+                            @LicensesBuilder licenses: () -> [Licensable] = { [] }) {
         let aboutView = AboutView(repository: repository,
                                   copyright: copyright,
                                   actions: actions,

--- a/Sources/Diligence/Extensions/View.swift
+++ b/Sources/Diligence/Extensions/View.swift
@@ -24,7 +24,7 @@ extension View {
 
     func prefersUnderline() -> some View {
 #if compiler(>=5.7)
-        if #available(macOS 13.0, *) {
+        if #available(macOS 13.0, iOS 16.0, *) {
             return underline()
         } else {
             return self

--- a/Sources/Diligence/Extensions/View.swift
+++ b/Sources/Diligence/Extensions/View.swift
@@ -20,35 +20,17 @@
 
 import SwiftUI
 
-import Licensable
+extension View {
 
-struct LicenseView: View {
-
-    private var license: Licensable
-
-    init(_ license: Licensable) {
-        self.license = license
-    }
-
-    var body: some View {
-        List {
-            LabeledContent("Author", value: license.author)
-            ForEach(license.attributes) { attribute in
-                switch attribute.value {
-                case .text(let text):
-                    LabeledContent(attribute.name, value: text)
-                case .url(let url):
-                    Link(attribute.name, url: url)
-                }
-            }
-            .prefersTextualRepresentation()
-            Text(license.text)
-                .textSelection(.enabled)
-                .padding(.top, 8)
+    func prefersUnderline() -> some View {
+#if compiler(>=5.7)
+        if #available(macOS 13.0, *) {
+            return underline()
+        } else {
+            return self
         }
-        .listStyle(PlainListStyle())
-#if os(iOS)
-        .navigationBarTitle(license.name, displayMode: .inline)
+#else
+        return self
 #endif
     }
 

--- a/Sources/Diligence/Model/Contents.swift
+++ b/Sources/Diligence/Model/Contents.swift
@@ -20,6 +20,8 @@
 
 import Foundation
 
+import Licensable
+
 public struct Contents {
 
     let repository: String?
@@ -44,7 +46,7 @@ public struct Contents {
                 copyright: String? = nil,
                 @ActionsBuilder actions: () -> [Action],
                 @AcknowledgementsBuilder acknowledgements: () -> [Acknowledgements] = { [] },
-                @LicensesBuilder licenses: () -> [License] = { [] }) {
+                @LicensesBuilder licenses: () -> [Licensable] = { [] }) {
         self.init(repository: repository,
                   copyright: copyright,
                   actions: actions,

--- a/Sources/Diligence/Model/License.swift
+++ b/Sources/Diligence/Model/License.swift
@@ -22,68 +22,54 @@ import Foundation
 
 import Licensable
 
-// TODO: Attributes need to be identifiable
+public struct License: Identifiable, Licensable {
 
-extension Attribute: Identifiable {
-
-    public var id: String {
-        return name
-    }
-
-}
-
-// TODO: Implement this
-
-extension Attribute.Value {
-
-    public static func == (lhs: Attribute.Value, rhs: Attribute.Value) -> Bool {
-        // TODO: THIS IS WRONG
-        return true
-    }
-
-}
-
-extension Attribute: Equatable {
-
-    public static func == (lhs: Attribute, rhs: Attribute) -> Bool {
-        return lhs.name == rhs.name && lhs.value == rhs.value
-    }
-
-}
-
-public struct License: Identifiable, Hashable, Licensable {
-
-    public var id = UUID().uuidString
-
+    public var id: String
     public let name: String
     public let author: String
     public let text: String
     public let attributes: [Attribute]
+    public let licenses: [Licensable]
 
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(id)
-    }
-
-    public init(name: String, author: String, attributes: [NamedURL] = [], text: String) {
+    public init(id: String = UUID().uuidString,
+                name: String,
+                author: String,
+                attributes: [NamedURL] = [],
+                text: String,
+                licenses: [Licensable] = []) {
+        self.id = id
         self.name = name
         self.author = author
         self.attributes = attributes.map { namedURL in
             return .url(namedURL.url, title: namedURL.name)
         }
         self.text = text
+        self.licenses = licenses
     }
 
-    public init(_ name: String, author: String, attributes: [NamedURL] = [], text: String) {
-        self.init(name: name, author: author, attributes: attributes, text: text)
+    public init(_ name: String,
+                author: String,
+                attributes: [NamedURL] = [],
+                text: String,
+                licenses: [Licensable] = []) {
+        self.init(name: name, author: author, attributes: attributes, text: text, licenses: licenses)
     }
 
-    public init(name: String, author: String, attributes: [NamedURL] = [], filename: String, bundle: Bundle = Bundle.main) {
+    public init(id: String = UUID().uuidString,
+                name: String,
+                author: String,
+                attributes: [NamedURL] = [],
+                filename: String,
+                bundle: Bundle = Bundle.main,
+                licenses: [Licensable] = []) {
+        self.id = id
         self.name = name
         self.author = author
         self.attributes = attributes.map { namedURL in
             return .url(namedURL.url, title: namedURL.name)
         }
         self.text = String(contentsOfBundleFile: filename, bundle: bundle)!
+        self.licenses = licenses
     }
 
     public init(_ name: String,
@@ -94,37 +80,15 @@ public struct License: Identifiable, Hashable, Licensable {
         self.init(name: name, author: author, attributes: attributes, filename: filename, bundle: bundle)
     }
 
-    public init(_ name: String, author: String, attributes: [NamedURL] = [], url: URL) {
+    public init(_ name: String, author: String, attributes: [NamedURL] = [], url: URL, licenses: [Licensable] = []) {
+        self.id = UUID().uuidString
         self.name = name
         self.author = author
         self.attributes = attributes.map { namedURL in
             return .url(namedURL.url, title: namedURL.name)
         }
         self.text = try! String(contentsOf: url)
-    }
-
-}
-
-extension License {
-
-    public init(_ licensable: Licensable) {
-        self.init(licensable.name, author: licensable.author, text: licensable.text)
-    }
-
-}
-
-extension Array where Element == Licensable {
-
-    /// Return an array ensuing the built-in Diligence license exists, and exists only once in the array.
-    func includingDiligenceLicense() -> [Licensable] {
-        return self + [Legal.license]
-    }
-
-    /// Sort licenses alphabetically by name.
-    func sorted() -> [Licensable] {
-        return sorted {
-            $0.name.localizedCompare($1.name) == .orderedAscending
-        }
+        self.licenses = licenses
     }
 
 }

--- a/Sources/Diligence/Model/LicenseGroup.swift
+++ b/Sources/Diligence/Model/LicenseGroup.swift
@@ -25,7 +25,6 @@ import Licensable
 public struct LicenseGroup: Identifiable, Equatable {
 
     public static func == (lhs: LicenseGroup, rhs: LicenseGroup) -> Bool {
-        // TODO: Do we need more?
         return lhs.id == rhs.id
     }
 
@@ -37,9 +36,9 @@ public struct LicenseGroup: Identifiable, Equatable {
     public init(_ title: String, includeDiligenceLicense: Bool = false, licenses: [Licensable]) {
         self.title = title
         if includeDiligenceLicense {
-            self.licenses = licenses.includingDiligenceLicense().sortedByName().map({ AnyLicensable($0) })
+            self.licenses = licenses.includingDiligenceLicense().flatten().sortedByName().eraseToAnyLicensable()
         } else {
-            self.licenses = licenses.sortedByName().map({ AnyLicensable($0) })
+            self.licenses = licenses.flatten().sortedByName().eraseToAnyLicensable()
         }
     }
 

--- a/Sources/Diligence/Model/LicenseGroup.swift
+++ b/Sources/Diligence/Model/LicenseGroup.swift
@@ -20,23 +20,30 @@
 
 import SwiftUI
 
+import Licensable
+
 public struct LicenseGroup: Identifiable, Equatable {
+
+    public static func == (lhs: LicenseGroup, rhs: LicenseGroup) -> Bool {
+        // TODO: Do we need more?
+        return lhs.id == rhs.id
+    }
 
     public let id = UUID()
 
     let title: String
-    let licenses: [License]
+    let licenses: [AnyLicensable]
 
-    public init(_ title: String, includeDiligenceLicense: Bool = false, licenses: [License]) {
+    public init(_ title: String, includeDiligenceLicense: Bool = false, licenses: [Licensable]) {
         self.title = title
         if includeDiligenceLicense {
-            self.licenses = licenses.includingDiligenceLicense().sortedByName()
+            self.licenses = licenses.includingDiligenceLicense().sortedByName().map({ AnyLicensable($0) })
         } else {
-            self.licenses = licenses.sortedByName()
+            self.licenses = licenses.sortedByName().map({ AnyLicensable($0) })
         }
     }
 
-    public init(_ title: String, includeDiligenceLicense: Bool = false, @LicensesBuilder licenses: () -> [License]) {
+    public init(_ title: String, includeDiligenceLicense: Bool = false, @LicensesBuilder licenses: () -> [Licensable]) {
         self.init(title, includeDiligenceLicense: includeDiligenceLicense, licenses: licenses())
     }
 

--- a/Sources/Diligence/Scenes/AboutWindowGroup.swift
+++ b/Sources/Diligence/Scenes/AboutWindowGroup.swift
@@ -20,6 +20,8 @@
 
 import SwiftUI
 
+import Licensable
+
 #if compiler(>=5.7) && os(macOS)
 
 @available(macOS 13, *)
@@ -50,7 +52,7 @@ public struct AboutWindowGroup: Scene {
                 copyright: String? = nil,
                 @ActionsBuilder actions: () -> [Action],
                 @AcknowledgementsBuilder acknowledgements: () -> [Acknowledgements] = { [] },
-                @LicensesBuilder licenses: () -> [License] = { [] }) {
+                @LicensesBuilder licenses: () -> [Licensable] = { [] }) {
         self.init(repository: repository,
                   copyright: copyright,
                   actions: actions,

--- a/Sources/Diligence/Scenes/MacLicenseWindowGroup.swift
+++ b/Sources/Diligence/Scenes/MacLicenseWindowGroup.swift
@@ -20,6 +20,8 @@
 
 import SwiftUI
 
+import Licensable
+
 #if compiler(>=5.7) && os(macOS)
 
 @available(macOS 13, *)
@@ -27,7 +29,7 @@ struct MacLicenseWindowGroup: Scene {
 
     static let windowID = "diligence-license-window"
 
-    let licenses: [License]
+    let licenses: [Licensable]
 
     var body: some Scene {
         WindowGroup(id: Self.windowID, for: License.ID.self) { $licenseId in

--- a/Sources/Diligence/Scenes/MacLicenseWindowGroup.swift
+++ b/Sources/Diligence/Scenes/MacLicenseWindowGroup.swift
@@ -29,11 +29,20 @@ struct MacLicenseWindowGroup: Scene {
 
     static let windowID = "diligence-license-window"
 
-    let licenses: [Licensable]
+    let licenses: [License.ID: Licensable]
+
+    init(licenses: [Licensable]) {
+        self.licenses = licenses
+            .includingDiligenceLicense()
+            .flatten()
+            .reduce(into: [License.ID: Licensable]()) { partialResult, licensable in
+                partialResult[licensable.id] = licensable
+            }
+    }
 
     var body: some Scene {
         WindowGroup(id: Self.windowID, for: License.ID.self) { $licenseId in
-            if let license = licenses.includingDiligenceLicense().first(where: { $0.id == licenseId }) {
+            if let licenseId, let license = licenses[licenseId] {
                 MacLicenseView(license: license)
             }
         }

--- a/Sources/Diligence/Styles/AttributeLabeledContentStyle.swift
+++ b/Sources/Diligence/Styles/AttributeLabeledContentStyle.swift
@@ -18,10 +18,31 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import Foundation
+import SwiftUI
 
-struct Legal {
+#if compiler(>=5.7) && os(macOS)
 
-    static let license = License("Diligence", author: "Jason Morley", filename: "LICENSE", bundle: .module)
+struct AttributeLabeledContentStyle: LabeledContentStyle {
+
+    func makeBody(configuration: Configuration) -> some View {
+        HStack {
+            configuration.label
+            Spacer()
+            configuration.content
+                .foregroundColor(.secondary)
+                .textSelection(.enabled)
+        }
+    }
 
 }
+
+@available(macOS 13, *)
+extension LabeledContentStyle where Self == AttributeLabeledContentStyle {
+
+    static var attribute: AttributeLabeledContentStyle {
+        return AttributeLabeledContentStyle()
+    }
+
+}
+
+#endif

--- a/Sources/Diligence/View Modifiers/Hyperlink.swift
+++ b/Sources/Diligence/View Modifiers/Hyperlink.swift
@@ -20,9 +20,6 @@
 
 import SwiftUI
 
-#if compiler(>=5.7)
-
-@available(iOS 16, *, macOS 13, *)
 struct Hyperlink: ViewModifier {
 
     @State var isHovering = false
@@ -32,7 +29,7 @@ struct Hyperlink: ViewModifier {
     func body(content: Content) -> some View {
         content
             .textSelection(.disabled)
-            .underline()
+            .prefersUnderline()
             .foregroundColor(.accentColor)
             .onTapGesture(perform: action)
             .brightness(isHovering ? 0.2 : 0.0)
@@ -50,7 +47,6 @@ struct Hyperlink: ViewModifier {
 
 }
 
-@available(iOS 16, *, macOS 13, *)
 extension View {
 
     func hyperlink(_ perform: @escaping () -> Void) -> some View {
@@ -58,5 +54,3 @@ extension View {
     }
 
 }
-
-#endif

--- a/Sources/Diligence/Views/LicenseRow.swift
+++ b/Sources/Diligence/Views/LicenseRow.swift
@@ -20,13 +20,15 @@
 
 import SwiftUI
 
+import Licensable
+
 public struct LicenseRow: View {
 
-    var license: License
+    var license: Licensable
 
     @State var isShowingDetails = false
 
-    public init(_ license: License) {
+    public init(_ license: Licensable) {
         self.license = license
     }
 

--- a/Sources/Diligence/Views/LicenseSection.swift
+++ b/Sources/Diligence/Views/LicenseSection.swift
@@ -29,8 +29,7 @@ public struct LicenseSection: View {
 
     public init(_ title: String? = nil, _ licenses: [Licensable]) {
         self.title = title
-        // TODO: Convenience map
-        self.licenses = licenses.sorted().map({ AnyLicensable($0) })
+        self.licenses = licenses.flatten().sortedByName().eraseToAnyLicensable()
     }
 
     public init(_ title: String? = nil, @LicensesBuilder licenses: () -> [License]) {

--- a/Sources/Diligence/Views/LicenseSection.swift
+++ b/Sources/Diligence/Views/LicenseSection.swift
@@ -22,26 +22,6 @@ import SwiftUI
 
 import Licensable
 
-// TODO:
-
-struct AnyLicensable: Identifiable, Licensable {
-
-    let id: String
-    let name: String
-    let author: String
-    let text: String
-    let attributes: [Attribute]
-
-    init<T: Licensable>(_ licensable: T) {
-        id = licensable.id
-        name = licensable.name
-        author = licensable.author
-        text = licensable.text
-        attributes = licensable.attributes
-    }
-
-}
-
 public struct LicenseSection: View {
 
     var title: String?

--- a/Sources/Diligence/Views/LicenseSection.swift
+++ b/Sources/Diligence/Views/LicenseSection.swift
@@ -32,7 +32,7 @@ public struct LicenseSection: View {
         self.licenses = licenses.flatten().sortedByName().eraseToAnyLicensable()
     }
 
-    public init(_ title: String? = nil, @LicensesBuilder licenses: () -> [License]) {
+    public init(_ title: String? = nil, @LicensesBuilder licenses: () -> [Licensable]) {
         self.init(title, licenses())
     }
 

--- a/Sources/Diligence/Views/LicenseSection.swift
+++ b/Sources/Diligence/Views/LicenseSection.swift
@@ -20,14 +20,37 @@
 
 import SwiftUI
 
+import Licensable
+
+// TODO:
+
+struct AnyLicensable: Identifiable, Licensable {
+
+    let id: String
+    let name: String
+    let author: String
+    let text: String
+    let attributes: [Attribute]
+
+    init<T: Licensable>(_ licensable: T) {
+        id = licensable.id
+        name = licensable.name
+        author = licensable.author
+        text = licensable.text
+        attributes = licensable.attributes
+    }
+
+}
+
 public struct LicenseSection: View {
 
     var title: String?
-    var licenses: [License]
+    var licenses: [AnyLicensable]
 
-    public init(_ title: String? = nil, _ licenses: [License]) {
+    public init(_ title: String? = nil, _ licenses: [Licensable]) {
         self.title = title
-        self.licenses = licenses.sorted()
+        // TODO: Convenience map
+        self.licenses = licenses.sorted().map({ AnyLicensable($0) })
     }
 
     public init(_ title: String? = nil, @LicensesBuilder licenses: () -> [License]) {

--- a/Sources/Diligence/Views/LicenseView.swift
+++ b/Sources/Diligence/Views/LicenseView.swift
@@ -20,11 +20,13 @@
 
 import SwiftUI
 
+import Licensable
+
 struct LicenseView: View {
 
-    private var license: License
+    private var license: Licensable
 
-    init(_ license: License) {
+    init(_ license: Licensable) {
         self.license = license
     }
 
@@ -32,7 +34,8 @@ struct LicenseView: View {
         List {
             LabeledContent("Author", value: license.author)
             ForEach(license.attributes) { attribute in
-                Link(attribute.name, url: attribute.url)
+                Text("AN ATTRIBUTE")
+//                Link(attribute.name, url: attribute.url)
             }
             .prefersTextualRepresentation()
             Text(license.text)

--- a/Sources/Diligence/Views/Link.swift
+++ b/Sources/Diligence/Views/Link.swift
@@ -45,6 +45,7 @@ public struct Link: View {
     }
 
     public var body: some View {
+#if os(iOS)
         Button {
             openURL(url)
         } label: {
@@ -64,5 +65,14 @@ public struct Link: View {
             }
         }
         .foregroundColor(.primary)
+        .buttonStyle(.plain)
+#else
+        LabeledContent(text) {
+            Text(url.absoluteString)
+                .hyperlink {
+                    openURL(url)
+                }
+        }
+#endif
     }
 }

--- a/Sources/Diligence/Views/MacAboutView.swift
+++ b/Sources/Diligence/Views/MacAboutView.swift
@@ -92,7 +92,7 @@ public struct MacAboutView: View {
                 copyright: String? = nil,
                 @ActionsBuilder actions: () -> [Action],
                 @AcknowledgementsBuilder acknowledgements: () -> [Acknowledgements] = { [] },
-                @LicensesBuilder licenses: () -> [License] = { [] },
+                @LicensesBuilder licenses: () -> [Licensable] = { [] },
                 usesAppKit: Bool = false) {
         self.init(repository: repository,
                   copyright: copyright,

--- a/Sources/Diligence/Views/MacAboutView.swift
+++ b/Sources/Diligence/Views/MacAboutView.swift
@@ -20,6 +20,8 @@
 
 import SwiftUI
 
+import Licensable
+
 #if compiler(>=5.7) && os(macOS)
 
 @available(macOS 13, *)
@@ -40,7 +42,7 @@ public struct MacAboutView: View {
     private let licenseGroups: [LicenseGroup]
     private let usesAppKit: Bool
 
-    func openLicenseWindow(_ license: License) {
+    func openLicenseWindow(_ license: Licensable) {
 
         // Check to see if the window is already open and activate it if it is.
         for window in NSApplication.shared.windows {

--- a/Sources/Diligence/Views/MacLicenseView.swift
+++ b/Sources/Diligence/Views/MacLicenseView.swift
@@ -20,6 +20,8 @@
 
 import SwiftUI
 
+import Licensable
+
 #if compiler(>=5.7) && os(macOS)
 
 @available(macOS 13, *)
@@ -30,7 +32,7 @@ struct MacLicenseView: View {
         static let height = 500.0
     }
 
-    var license: License
+    var license: Licensable
 
     var body: some View {
         ScrollView {

--- a/Sources/Diligence/Views/MacLicenseView.swift
+++ b/Sources/Diligence/Views/MacLicenseView.swift
@@ -30,22 +30,28 @@ struct MacLicenseView: View {
     private struct LayoutMetrics {
         static let width = 400.0
         static let height = 500.0
+        static let interItemSpacing = 16.0
     }
 
     var license: Licensable
 
     var body: some View {
         ScrollView {
-            VStack {
-                HStack {
-                    Text("Author")
-                    Spacer()
-                    Text(license.author)
-                        .foregroundColor(.secondary)
+            VStack(spacing: LayoutMetrics.interItemSpacing) {
+                LabeledContent("Author", value: license.author)
+                ForEach(license.attributes) { attribute in
+                    switch attribute.value {
+                    case .text(let text):
+                        LabeledContent(attribute.name, value: text)
+                    case .url(let url):
+                        Link(attribute.name, url: url)
+                    }
                 }
+                .prefersTextualRepresentation()
                 Divider()
                 Text(license.text)
             }
+            .labeledContentStyle(.attribute)
             .padding()
         }
         .safeAreaInset(edge: .bottom) {

--- a/Sources/Diligence/Views/PhoneAboutView.swift
+++ b/Sources/Diligence/Views/PhoneAboutView.swift
@@ -21,6 +21,8 @@
 import Combine
 import SwiftUI
 
+import Licensable
+
 #if compiler(>=5.7) && os(iOS)
 
 public struct PhoneAboutView: View {

--- a/Sources/Diligence/Views/PhoneAboutView.swift
+++ b/Sources/Diligence/Views/PhoneAboutView.swift
@@ -56,7 +56,7 @@ public struct PhoneAboutView: View {
                 copyright: String? = nil,
                 @ActionsBuilder actions: () -> [Action] = { [] },
                 @AcknowledgementsBuilder acknowledgements: () -> [Acknowledgements] = { [] },
-                @LicensesBuilder licenses: () -> [License] = { [] },
+                @LicensesBuilder licenses: () -> [Licensable] = { [] },
                 usesAppKit: Bool = false) {
         self.init(repository: repository,
                   copyright: copyright,

--- a/Sources/Diligence/Windows/NSLicenseWindow.swift
+++ b/Sources/Diligence/Windows/NSLicenseWindow.swift
@@ -20,14 +20,16 @@
 
 import SwiftUI
 
+import Licensable
+
 #if compiler(>=5.7) && os(macOS)
 
 @available(macOS 13, *)
 class NSLicenseWindow: NSWindow {
 
-    var license: License! = nil
+    var license: Licensable! = nil
 
-    convenience init(license: License) {
+    convenience init(license: Licensable) {
         let licenseView = MacLicenseView(license: license)
         self.init(contentViewController: NSHostingController(rootView: licenseView))
         self.license = license

--- a/Tests/DiligenceTests/DiligenceTests.swift
+++ b/Tests/DiligenceTests/DiligenceTests.swift
@@ -21,21 +21,23 @@
 import XCTest
 @testable import Diligence
 
+import Licensable
+
 final class DiligenceTests: XCTestCase {
 
     func testEquivalence() {
 
-        XCTAssertNotEquivalent([License("Fromage", author: "Fromage", text: "skdjfh")],
-                               [License("Cheese", author: "Fromage", text: "skdjfh")])
+        XCTAssertNotEquivalent([License("Fromage", author: "Fromage", text: "skdjfh")].eraseToAnyLicensable(),
+                               [License("Cheese", author: "Fromage", text: "skdjfh")].eraseToAnyLicensable())
 
-        XCTAssertNotEquivalent([License("Cheese", author: "Fromage", text: "skdjfh")],
-                               [License("Cheese", author: "Fromage", text: "skdjfkjshdfh")])
+        XCTAssertNotEquivalent([License("Cheese", author: "Fromage", text: "skdjfh")].eraseToAnyLicensable(),
+                               [License("Cheese", author: "Fromage", text: "skdjfkjshdfh")].eraseToAnyLicensable())
 
-        XCTAssertNotEquivalent([License("Cheese", author: "Fromage", text: "skdjfh")],
-                            [License("Cheese", author: "Random", text: "skdjfh")])
+        XCTAssertNotEquivalent([License("Cheese", author: "Fromage", text: "skdjfh")].eraseToAnyLicensable(),
+                            [License("Cheese", author: "Random", text: "skdjfh")].eraseToAnyLicensable())
 
-        XCTAssertEquivalent([License("Cheese", author: "Fromage", text: "skdjfh")],
-                            [License("Cheese", author: "Fromage", text: "skdjfh")])
+        XCTAssertEquivalent([License("Cheese", author: "Fromage", text: "skdjfh")].eraseToAnyLicensable(),
+                            [License("Cheese", author: "Fromage", text: "skdjfh")].eraseToAnyLicensable())
     }
 
     func testContents() {
@@ -49,23 +51,24 @@ final class DiligenceTests: XCTestCase {
         } licenses: {
             License("Name", author: "Author", text: "License")
         }
+
         XCTAssertEquivalent(contents.licenseGroups,
                             [LicenseGroup("Licenses", licenses: [
                                 License("Name", author: "Author", text: "License"),
-                                Diligence.Legal.license,
+                                .diligence,
                             ])])
     }
 
     func testLicenseGroup() {
 
         let licenseGroup = LicenseGroup("Fonts") {
-            License("One", author: "Two", text: "Three")
-            License("Four", author: "Five", text: "Six")
+            License("One", author: "Two", text: "Three").eraseToAnyLicensable()
+            License("Four", author: "Five", text: "Six").eraseToAnyLicensable()
         }
         XCTAssertEqual(licenseGroup.title, "Fonts")
         XCTAssertEquivalent(licenseGroup.licenses, [
-            License("Four", author: "Five", text: "Six"),
-            License("One", author: "Two", text: "Three"),
+            License("Four", author: "Five", text: "Six").eraseToAnyLicensable(),
+            License("One", author: "Two", text: "Three").eraseToAnyLicensable(),
         ])
 
     }
@@ -77,11 +80,13 @@ final class DiligenceTests: XCTestCase {
             License("Four", author: "Five", text: "Six")
         }
         XCTAssertEqual(licenseGroup.title, "Fonts")
-        XCTAssertEquivalent(licenseGroup.licenses, [
-            Diligence.Legal.license,
+
+        let expected: [Licensable] = [
+            .diligence,
             License("Four", author: "Five", text: "Six"),
             License("One", author: "Two", text: "Three"),
-        ])
+        ]
+        XCTAssertEquivalent(licenseGroup.licenses, expected.eraseToAnyLicensable())
     }
 
 }

--- a/Tests/DiligenceTests/DiligenceTests.swift
+++ b/Tests/DiligenceTests/DiligenceTests.swift
@@ -84,6 +84,7 @@ final class DiligenceTests: XCTestCase {
         let expected: [Licensable] = [
             .diligence,
             License("Four", author: "Five", text: "Six"),
+            .licensable,
             License("One", author: "Two", text: "Three"),
         ]
         XCTAssertEquivalent(licenseGroup.licenses, expected.eraseToAnyLicensable())

--- a/Tests/DiligenceTests/Equivalence.swift
+++ b/Tests/DiligenceTests/Equivalence.swift
@@ -20,6 +20,8 @@
 
 import XCTest
 
+import Licensable
+
 @testable import Diligence
 
 protocol Equivalence {
@@ -47,9 +49,9 @@ extension LicenseGroup: Equivalence {
 
 }
 
-extension License: Equivalence {
+extension AnyLicensable: Equivalence {
 
-    func isEquivalent(_ other: License) -> Bool {
+    func isEquivalent(_ other: AnyLicensable) -> Bool {
         return (self.name == other.name &&
                 self.author == other.author &&
                 self.text == other.text)


### PR DESCRIPTION
This change introduces the `Licensable` protocol to allow Swift packages to conveniently export their own licenses in a common format for ease of use with Diligence.