### PR TITLE
fix: Add `License` constructor compatible with `Licensable.License`

### DIFF
--- a/Sources/Diligence/Extensions/Licensable.swift
+++ b/Sources/Diligence/Extensions/Licensable.swift
@@ -30,6 +30,9 @@ extension Licensable where Self == License {
                        name: "Diligence",
                        author: "Jason Morley",
                        text: try! String(contentsOf: licenseURL),
+                       attributes: [
+                           .url(URL(string: "https://github.com/inseven/diligence")!, title: "GitHub"),
+                       ],
                        licenses: [
                            .licensable
                        ])

--- a/Sources/Diligence/Model/License.swift
+++ b/Sources/Diligence/Model/License.swift
@@ -34,6 +34,20 @@ public struct License: Identifiable, Licensable {
     public init(id: String = UUID().uuidString,
                 name: String,
                 author: String,
+                text: String,
+                attributes: [Attribute] = [],
+                licenses: [Licensable] = []) {
+        self.id = id
+        self.name = name
+        self.author = author
+        self.text = text
+        self.attributes = attributes
+        self.licenses = licenses
+    }
+
+    public init(id: String = UUID().uuidString,
+                name: String,
+                author: String,
                 attributes: [NamedURL] = [],
                 text: String,
                 licenses: [Licensable] = []) {


### PR DESCRIPTION
This change also adds the Diligence GitHub URL to its license declaration.