### PR TITLE
fix: Support license groups in AppKit constructors

### DIFF
--- a/Sources/Diligence/Extensions/NSWindow.swift
+++ b/Sources/Diligence/Extensions/NSWindow.swift
@@ -45,6 +45,24 @@ extension NSWindow {
         self.styleMask.remove(.miniaturizable)
     }
 
+    @available(macOS 13, *)
+    public convenience init(repository: String? = nil,
+                            copyright: String? = nil,
+                            @ActionsBuilder actions: () -> [Action],
+                            @AcknowledgementsBuilder acknowledgements: () -> [Acknowledgements] = { [] },
+                            @LicenseGroupsBuilder licenses: () -> [LicenseGroup] = { [] }) {
+        let aboutView = AboutView(repository: repository,
+                                  copyright: copyright,
+                                  actions: actions,
+                                  acknowledgements: acknowledgements,
+                                  licenses: licenses,
+                                  usesAppKit: true)
+        self.init(contentViewController: NSHostingController(rootView: aboutView))
+        self.title = Bundle.main.aboutWindowTitle
+        self.styleMask.remove(.resizable)
+        self.styleMask.remove(.miniaturizable)
+    }
+
 }
 
 #endif

--- a/Sources/Diligence/Scenes/MacLicenseWindowGroup.swift
+++ b/Sources/Diligence/Scenes/MacLicenseWindowGroup.swift
@@ -27,7 +27,7 @@ import Licensable
 @available(macOS 13, *)
 struct MacLicenseWindowGroup: Scene {
 
-    private struct LayoutMetrics {
+    struct LayoutMetrics {
         static let width = 500.0
         static let height = 600.0
     }

--- a/Sources/Diligence/Views/MacAboutView.swift
+++ b/Sources/Diligence/Views/MacAboutView.swift
@@ -57,6 +57,8 @@ public struct MacAboutView: View {
 
         // If not, create a new license window.
         let window = NSLicenseWindow(license: license)
+        window.setContentSize(NSSize(width: MacLicenseWindowGroup.LayoutMetrics.width,
+                                     height: MacLicenseWindowGroup.LayoutMetrics.width))
         window.makeKeyAndOrderFront(nil)
     }
 

--- a/Sources/Diligence/Windows/NSLicenseWindow.swift
+++ b/Sources/Diligence/Windows/NSLicenseWindow.swift
@@ -34,7 +34,6 @@ class NSLicenseWindow: NSWindow {
         self.init(contentViewController: NSHostingController(rootView: licenseView))
         self.license = license
         self.title = license.name
-        self.styleMask.remove(.resizable)
         self.styleMask.remove(.miniaturizable)
     }
 


### PR DESCRIPTION
This change also includes a drive-by fix for the initial window dimensions of AppKit windows.