### PR TITLE
fix: Show commit shas in monospaced font and drop highlight underlines

### DIFF
--- a/Sources/Diligence/View Modifiers/Hyperlink.swift
+++ b/Sources/Diligence/View Modifiers/Hyperlink.swift
@@ -29,7 +29,7 @@ struct Hyperlink: ViewModifier {
     func body(content: Content) -> some View {
         content
             .textSelection(.disabled)
-            .prefersUnderline()
+            .underlinesForDifferentiation()
             .foregroundColor(.accentColor)
             .onTapGesture(perform: action)
             .brightness(isHovering ? 0.2 : 0.0)

--- a/Sources/Diligence/View Modifiers/UnderlinesForDifferentiation.swift
+++ b/Sources/Diligence/View Modifiers/UnderlinesForDifferentiation.swift
@@ -20,18 +20,32 @@
 
 import SwiftUI
 
-extension View {
+private struct UnderlinesForDifferentiation: ViewModifier {
 
-    func prefersMonospaced() -> some View {
+    @Environment(\.accessibilityDifferentiateWithoutColor) var accessibilityDifferentiateWithoutColor
+
+    func body(content: Content) -> some View {
 #if compiler(>=5.7)
         if #available(macOS 13.0, iOS 16.0, *) {
-            return monospaced()
+            if accessibilityDifferentiateWithoutColor {
+                content
+                    .underline()
+            } else {
+                content
+            }
         } else {
-            return self
+            content
         }
 #else
-        return self
+        content
 #endif
+    }
+}
+
+extension View {
+
+    func underlinesForDifferentiation() -> some View {
+        return modifier(UnderlinesForDifferentiation())
     }
 
 }

--- a/Sources/Diligence/Views/BuildSection.swift
+++ b/Sources/Diligence/Views/BuildSection.swift
@@ -73,6 +73,7 @@ public struct BuildSection<Header: View>: View {
                                 .foregroundColor(.primary)
                             Spacer()
                             Text(commit)
+                                .prefersMonospaced()
                                 .foregroundColor(.secondary)
                                 .textSelection(.enabled)
                         }

--- a/Sources/Diligence/Views/MacAboutView.swift
+++ b/Sources/Diligence/Views/MacAboutView.swift
@@ -169,6 +169,7 @@ public struct MacAboutView: View {
                    let url = Bundle.main.commitUrl(for: repository),
                    let commit = Bundle.main.commit {
                     Text(commit)
+                        .prefersMonospaced()
                         .hyperlink {
                             openURL(url)
                         }


### PR DESCRIPTION
This change preserves underlines if differentiate without color is set.