### PR TITLE
fix: Consistent build details on macOS and iOS

### DIFF
--- a/Sources/Diligence/Extensions/Bundle.swift
+++ b/Sources/Diligence/Extensions/Bundle.swift
@@ -39,7 +39,22 @@ extension Bundle {
     }
 
     public var build: String? {
-        return Bundle.main.infoDictionary?["CFBundleVersion"] as? String
+//        return Bundle.main.infoDictionary?["CFBundleVersion"] as? String
+        return "240330230605938340"
+    }
+
+    public var extendedVersion: String? {
+        var components: [String] = []
+        if let version {
+            components.append(version)
+        }
+        if let build {
+            components.append(build)
+        }
+        guard !components.isEmpty else {
+            return nil
+        }
+        return components.joined(separator: ".")
     }
 
     public var utcBuildDate: Date? {

--- a/Sources/Diligence/Extensions/View.swift
+++ b/Sources/Diligence/Extensions/View.swift
@@ -34,4 +34,16 @@ extension View {
 #endif
     }
 
+    func prefersLinkForegroundStyle() -> some View {
+#if compiler(>=5.7)
+        if #available(macOS 14, iOS 17, *) {
+            return foregroundStyle(.link)
+        } else {
+            return self
+        }
+#else
+        return self
+#endif
+    }
+
 }

--- a/Sources/Diligence/Views/BuildSection.swift
+++ b/Sources/Diligence/Views/BuildSection.swift
@@ -49,11 +49,7 @@ public struct BuildSection<Header: View>: View {
     public var body: some View {
         Section(header: header) {
             LabeledContent("Version") {
-                Text(Bundle.main.version ?? "")
-                    .textSelection(.enabled)
-            }
-            LabeledContent("Build") {
-                Text(Bundle.main.build ?? "")
+                Text(Bundle.main.extendedVersion ?? "")
                     .textSelection(.enabled)
             }
             if let date = date {
@@ -74,6 +70,7 @@ public struct BuildSection<Header: View>: View {
                             Spacer()
                             Text(commit)
                                 .prefersMonospaced()
+                                .prefersLinkForegroundStyle()
                                 .foregroundColor(.secondary)
                                 .textSelection(.enabled)
                         }

--- a/Sources/Diligence/Views/MacAboutView.swift
+++ b/Sources/Diligence/Views/MacAboutView.swift
@@ -125,13 +125,10 @@ public struct MacAboutView: View {
                         .padding(.bottom)
                         MacAboutSection("Version") {
                             Text(Bundle.main.extendedVersion ?? "")
-                                .foregroundStyle(.secondary)
-                                .gridColumnAlignment(.leading)
                         }
                         if let date = Bundle.main.utcBuildDate {
                             MacAboutSection("Date") {
                                 Text(date, format: .dateTime)
-                                    .foregroundStyle(.secondary)
                             }
                         }
                         if let repository = repository,
@@ -184,21 +181,6 @@ public struct MacAboutView: View {
             .background(Color.textBackgroundColor)
             Divider()
             HStack {
-//                Text("Version \(Bundle.main.version ?? "") (\(Bundle.main.build ?? ""))")
-//                    .foregroundColor(.secondary)
-//                    .textSelection(.enabled)
-//                if let repository = repository,
-//                   let url = Bundle.main.commitUrl(for: repository),
-//                   let commit = Bundle.main.commit {
-//                    Text(commit)
-//                        .prefersMonospaced()
-//                        .hyperlink {
-//                            openURL(url)
-//                        }
-//                } else if let commit = Bundle.main.commit {
-//                    Text(commit)
-//                        .foregroundColor(.secondary)
-//                }
                 Spacer()
                 ForEach(actions) { action in
                     Button(action.title) {

--- a/Sources/Diligence/Views/MacAboutView.swift
+++ b/Sources/Diligence/Views/MacAboutView.swift
@@ -114,7 +114,7 @@ public struct MacAboutView: View {
                 .padding(.all, multiplier: 2)
                 ScrollView {
                     VStack {
-                        VStack(spacing: 8.0) {
+                        VStack(alignment: .leading, spacing: 8.0) {
                             ApplicationNameTitle()
                                 .horizontalSpace(.trailing)
                             if let copyright = copyright {
@@ -123,6 +123,28 @@ public struct MacAboutView: View {
                             }
                         }
                         .padding(.bottom)
+                        MacAboutSection("Version") {
+                            Text(Bundle.main.extendedVersion ?? "")
+                                .foregroundStyle(.secondary)
+                                .gridColumnAlignment(.leading)
+                        }
+                        if let date = Bundle.main.utcBuildDate {
+                            MacAboutSection("Date") {
+                                Text(date, format: .dateTime)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        if let repository = repository,
+                           let url = Bundle.main.commitUrl(for: repository),
+                           let commit = Bundle.main.commit {
+                            MacAboutSection("Commit") {
+                                Text(commit)
+                                    .prefersMonospaced()
+                                    .hyperlink {
+                                        openURL(url)
+                                    }
+                            }
+                        }
                         if !acknowledgements.isEmpty {
                             ForEach(acknowledgements) { acknowledgements in
                                 MacAboutSection(acknowledgements.title) {
@@ -162,21 +184,21 @@ public struct MacAboutView: View {
             .background(Color.textBackgroundColor)
             Divider()
             HStack {
-                Text("Version \(Bundle.main.version ?? "") (\(Bundle.main.build ?? ""))")
-                    .foregroundColor(.secondary)
-                    .textSelection(.enabled)
-                if let repository = repository,
-                   let url = Bundle.main.commitUrl(for: repository),
-                   let commit = Bundle.main.commit {
-                    Text(commit)
-                        .prefersMonospaced()
-                        .hyperlink {
-                            openURL(url)
-                        }
-                } else if let commit = Bundle.main.commit {
-                    Text(commit)
-                        .foregroundColor(.secondary)
-                }
+//                Text("Version \(Bundle.main.version ?? "") (\(Bundle.main.build ?? ""))")
+//                    .foregroundColor(.secondary)
+//                    .textSelection(.enabled)
+//                if let repository = repository,
+//                   let url = Bundle.main.commitUrl(for: repository),
+//                   let commit = Bundle.main.commit {
+//                    Text(commit)
+//                        .prefersMonospaced()
+//                        .hyperlink {
+//                            openURL(url)
+//                        }
+//                } else if let commit = Bundle.main.commit {
+//                    Text(commit)
+//                        .foregroundColor(.secondary)
+//                }
                 Spacer()
                 ForEach(actions) { action in
                     Button(action.title) {


### PR DESCRIPTION
This change aligns the macOS and iOS presentation of build details by combining the version and build numbers, and showing the build date on macOS.