### PR TITLE
feat: Use `BuildSection` for different bundle instances

### DIFF
--- a/Sources/Diligence/Extensions/Bundle.swift
+++ b/Sources/Diligence/Extensions/Bundle.swift
@@ -39,7 +39,7 @@ extension Bundle {
     }
 
     public var build: String? {
-        return Bundle.main.infoDictionary?["CFBundleVersion"] as? String
+        return infoDictionary?["CFBundleVersion"] as? String
     }
 
     public var extendedVersion: String? {
@@ -93,7 +93,7 @@ extension Bundle {
     }
 
     public var aboutWindowTitle: String {
-        return "About \(Bundle.main.preferredName ?? "")"
+        return "About \(preferredName ?? "")"
     }
 
 }

--- a/Sources/Diligence/Views/BuildSection.swift
+++ b/Sources/Diligence/Views/BuildSection.swift
@@ -31,29 +31,31 @@ public struct BuildSection<Header: View>: View {
         return dateFormatter
     }()
 
-    var project: String?
-    var header: Header?
+    private let project: String?
+    private let bundle: Bundle
+    private let header: Header?
 
     private var date: String? {
-        guard let date = Bundle.main.utcBuildDate else {
+        guard let date = bundle.utcBuildDate else {
             return nil
         }
         return dateFormatter.string(from: date)
     }
 
-    public init(_ project: String? = nil, @ViewBuilder header: () -> Header?) {
+    public init(_ project: String? = nil, bundle: Bundle = Bundle.main, @ViewBuilder header: () -> Header?) {
         self.project = project
+        self.bundle = bundle
         self.header = header()
     }
 
     public var body: some View {
         Section(header: header) {
             LabeledContent("Version") {
-                Text(Bundle.main.version ?? "")
+                Text(bundle.version ?? "")
                     .textSelection(.enabled)
             }
             LabeledContent("Build") {
-                Text(Bundle.main.build ?? "")
+                Text(bundle.build ?? "")
                     .textSelection(.enabled)
             }
             if let date = date {
@@ -62,9 +64,9 @@ public struct BuildSection<Header: View>: View {
                         .textSelection(.enabled)
                 }
             }
-            if let commit = Bundle.main.commit {
+            if let commit = bundle.commit {
                 if let project = project {
-                   let url = Bundle.main.commitUrl(for: project)
+                   let url = bundle.commitUrl(for: project)
                     Button {
                         if let url {
                             openURL(url)

--- a/Sources/Diligence/Views/BuildSection.swift
+++ b/Sources/Diligence/Views/BuildSection.swift
@@ -65,12 +65,19 @@ public struct BuildSection<Header: View>: View {
                 }
             }
             if let commit = bundle.commit {
-                if let project = project {
-                   let url = bundle.commitUrl(for: project)
+                if let project = project,
+                   let url = bundle.commitUrl(for: project) {
+#if os(macOS)
+                    LabeledContent("Commit") {
+                        Text(commit)
+                            .prefersMonospaced()
+                            .hyperlink {
+                                openURL(url)
+                            }
+                    }
+#else
                     Button {
-                        if let url {
-                            openURL(url)
-                        }
+                        openURL(url)
                     } label: {
                         HStack {
                             Text("Commit")
@@ -88,6 +95,7 @@ public struct BuildSection<Header: View>: View {
                             }
                         }
                     }
+#endif
                 } else {
                     LabeledContent("Commit") {
                         Text(commit)


### PR DESCRIPTION
This includes a drive-by fix to improve the appearance of `BuildSection` in `Form` on macOS.