### PR TITLE
feat: Expose `View.prefersTextualRepresentation`

### DIFF
--- a/Sources/Diligence/Environment/PrefersTextualRepresentationEnvironmentKey.swift
+++ b/Sources/Diligence/Environment/PrefersTextualRepresentationEnvironmentKey.swift
@@ -37,7 +37,7 @@ extension EnvironmentValues {
 
 extension View {
 
-    func prefersTextualRepresentation(_ prefersTextualRepresentation: Bool = true) -> some View {
+    public func prefersTextualRepresentation(_ prefersTextualRepresentation: Bool = true) -> some View {
         return environment(\.prefersTextualRepresentation, prefersTextualRepresentation)
     }
 

--- a/Sources/Diligence/Environment/PrefersTextualRepresentationEnvironmentKey.swift
+++ b/Sources/Diligence/Environment/PrefersTextualRepresentationEnvironmentKey.swift
@@ -22,7 +22,11 @@ import SwiftUI
 
 struct PrefersTextualRepresentationEnvironmentKey: EnvironmentKey {
 
+#if os(macOS)
+    public static var defaultValue: Bool = true
+#else
     public static var defaultValue: Bool = false
+#endif
 
 }
 

--- a/Sources/Diligence/Views/TextOrImage.swift
+++ b/Sources/Diligence/Views/TextOrImage.swift
@@ -20,51 +20,24 @@
 
 import SwiftUI
 
-public struct Link: View {
+struct TextOrImage: View {
 
-    @Environment(\.openURL) private var openURL
     @Environment(\.prefersTextualRepresentation) private var prefersTextualRepresentation
 
-    private let text: String
-    private let url: URL
+    let text: String
+    let systemImage: String
 
-    private var isMailto: Bool {
-        return url.scheme == "mailto"
-    }
-
-    private var image: String {
-        if isMailto {
-            return "envelope"
-        }
-        return "link"
-    }
-
-    public init(_ text: String, url: URL) {
-        self.text = text
-        self.url = url
-    }
-
-    public var body: some View {
-#if os(iOS)
-        Button {
-            openURL(url)
-        } label: {
-            LabeledContent(text) {
-                TextOrImage(text: url.absoluteString, systemImage: image)
-                    .foregroundColor(.secondary)
-            }
-        }
-        .foregroundColor(.primary)
-        .buttonStyle(.plain)
-#else
-        LabeledContent(text) {
-            TextOrImage(text: url.absoluteString, systemImage: image)
-                .hyperlink {
-                    openURL(url)
+    var body: some View {
+        if #available(iOS 16, *, macOS 13) {
+            ViewThatFits(in: .horizontal) {
+                if prefersTextualRepresentation {
+                    Text(text)
                 }
+                Image(systemName: systemImage)
+            }
+        } else {
+            Image(systemName: systemImage)
         }
-#endif
     }
+
 }
-
-


### PR DESCRIPTION
Controls whether links are displayed as symbols or full-text URLs.